### PR TITLE
投稿編集ページの実装

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,5 +1,7 @@
 class PostsController < ApplicationController
   before_action :authenticate_user!, except: :index
+  before_action :set_target_post, only: [:show, :edit, :update]
+  before_action :ensure_correct_user, only: [:edit, :update]
 
   def index
     @posts = Post.all
@@ -20,12 +22,34 @@ class PostsController < ApplicationController
   end
 
   def show
-    @post = Post.find(params[:id])
+  end
+
+  def edit
+  end
+
+  def update
+    if @post.update(post_params)
+      redirect_to post_path(@post.id), notice: "投稿を更新しました"
+    else
+      flash.now[:alert] = "投稿の編集に失敗しました"
+      render "edit"
+    end
   end
 
   private
 
   def post_params
     params.require(:post).permit(:title, :content, :extra_fee, :change, :image).merge(user_id: current_user.id)
+  end
+
+  def set_target_post
+    @post = Post.find(params[:id])
+  end
+
+  def ensure_correct_user
+    @post = Post.find(params[:id])
+    if @post.user_id != current_user.id
+      redirect_to root_path, alert: "他のユーザーの投稿は編集できません"
+    end
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,6 +8,7 @@
     <link rel="stylesheet" type="text/css" href="http://yui.yahooapis.com/3.18.1/build/cssreset/cssreset-min.css">
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
+    <script src="https://kit.fontawesome.com/dd65d3da0b.js" crossorigin="anonymous"></script>
   </head>
 
   <body>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -33,7 +33,11 @@
       <p class="error-messages"><%= post.errors.full_messages_for(:image)[0] %></P>
     </div>
     <div class="actions my-5 text-center">
-      <%= f.submit "ドリンクを投稿する" , class: "btn btn-outline-secondary w-50" %>
+      <% if local_assigns[:edit_flag].present? %>
+        <%= f.submit "投稿を変更する" , class: "btn btn-outline-secondary w-50" %>
+      <% else %>
+        <%= f.submit "ドリンクを投稿する" , class: "btn btn-outline-secondary w-50" %>
+      <% end %>
     </div>
   </div>
 <% end %>  

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -1,0 +1,8 @@
+<div class="container col-sm-12 col-11 pt-4">
+  <div class="row my-4">
+    <h3 class="fw-bold">投稿を編集する</h3>
+  </div>
+  <div class="row mb-4">
+    <%= render partial: "form", locals: { post: @post, :edit_flag => true} %>
+  </div>
+</div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,14 +1,16 @@
 <div class="post-show-container py-4 px-3">
   <div class="mb-3 d-flex justify-content-between">
     <div class="fs-3"><%= @post.title %></div>
-    <div class="dropdown">
-      <div class="fs-3" type="button" id="dropdownMenu2" data-bs-toggle="dropdown" aria-expanded="false">
-        <i class="fa-solid fa-pen-to-square"></i>
+    <% if @post.user_id == current_user.id %>
+      <div class="dropdown">
+        <div class="fs-3" type="button" id="dropdownMenu2" data-bs-toggle="dropdown" aria-expanded="false">
+          <i class="fa-solid fa-pen-to-square"></i>
+        </div>
+        <ul class="dropdown-menu" aria-labelledby="dropdownMenu2">
+          <li><%= link_to "編集する", edit_post_path(@post.id), class: "dropdown-item", type: "button" %></li>
+        </ul>
       </div>
-      <ul class="dropdown-menu" aria-labelledby="dropdownMenu2">
-        <li><%= link_to "編集する", edit_post_path(@post.id), class: "dropdown-item", type: "button" %></li>
-      </ul>
-    </div>
+    <% end %>
   </div>
   <div class="row">
     <div class="col-md-5 col-12 mb-3">

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,7 +1,17 @@
 <div class="post-show-container py-4 px-3">
-  <div class="row fs-3 px-3 mb-3"><%= @post.title %></div>
+  <div class="mb-3 d-flex justify-content-between">
+    <div class="fs-3"><%= @post.title %></div>
+    <div class="dropdown">
+      <div class="fs-3" type="button" id="dropdownMenu2" data-bs-toggle="dropdown" aria-expanded="false">
+        <i class="fa-solid fa-pen-to-square"></i>
+      </div>
+      <ul class="dropdown-menu" aria-labelledby="dropdownMenu2">
+        <li><%= link_to "編集する", edit_post_path(@post.id), class: "dropdown-item", type: "button" %></li>
+      </ul>
+    </div>
+  </div>
   <div class="row">
-    <div class="col-md-6 col-12 mb-3">
+    <div class="col-md-5 col-12 mb-3">
       <%= image_tag @post.image.url, class: "post-show-image w-100" %>
       <div class="post-user-detile d-flex mt-4">
         <div class="post-show-user-icon me-3">
@@ -15,7 +25,7 @@
       </div>
     </div>
     <div class="col-md-1 col-12"></div>
-    <div class="col-md-5 col-12 d-flex flex-column">
+    <div class="col-md-6 col-12 d-flex flex-column">
       <div class="mb-auto w-100 p-3 bg-white"><%= @post.content %></div>
       <div class="d-flex justify-content-between mt-3">
         <% if @post.change == "ちょい変" %>

--- a/spec/requests/posts_spec.rb
+++ b/spec/requests/posts_spec.rb
@@ -72,4 +72,63 @@ RSpec.describe "Posts", type: :request do
       expect(response).not_to have_http_status(200)
     end
   end
+
+  describe "GET #edit" do
+    before do
+      sign_in user
+      get edit_post_path(new_post)
+    end
+
+    it "レスポンスが正しく返ってくる事" do
+      expect(response).to have_http_status(200)
+    end
+
+    it "編集前のデータが表示されている事" do
+      expect(response.body).to include new_post.title
+      expect(response.body).to include new_post.content
+      expect(response.body).to include new_post.extra_fee.to_s
+      expect(response.body).to include new_post.change
+    end
+  end
+
+  describe "PATCH #update" do
+    before do
+      sign_in user
+    end
+
+    context "パラメーターが正常な場合" do
+      let!(:post_params) { attributes_for(:post, title: "other") }
+
+      it "リクエストが成功する事" do
+        patch post_path(new_post), params: { post: post_params }
+        expect(response).to have_http_status(302)
+      end
+
+      it "titleが更新される事" do
+        expect { 
+          patch post_path(new_post), params: { post: post_params }
+        }.to change { new_post.reload.title }.from("テスト投稿").to("other")
+      end
+    end
+
+    context "パラメーターが異常な場合" do
+      let(:invalid_post_params) { attributes_for(:post, :invalid) }
+      
+      it "リクエストが成功する事" do
+        patch post_path(new_post), params: { post: invalid_post_params }
+        expect(response).to have_http_status(200)  
+      end
+
+      it "titleが更新されない事" do
+        expect { 
+          patch post_path(new_post), params: { post: invalid_post_params }
+        }.not_to change(new_post.reload, :title)
+      end
+
+      it "エラーが表示される事" do
+        patch post_path(new_post), params: { post: invalid_post_params }
+        expect(response.body).to include "投稿の編集に失敗しました"  
+      end
+    end
+  end
 end

--- a/spec/requests/posts_spec.rb
+++ b/spec/requests/posts_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Posts", type: :request do
       get root_path
     end
 
-    it "レスポンスが正しく返ってくる事" do
+    it "リクエストが成功する事" do
       expect(response).to have_http_status(200)
     end
   end
@@ -20,7 +20,7 @@ RSpec.describe "Posts", type: :request do
       get new_post_path
     end
 
-    it "レスポンスが正しく返ってくる事" do
+    it "リクエストが成功する事" do
       expect(response).to have_http_status(200)
     end
   end
@@ -34,6 +34,11 @@ RSpec.describe "Posts", type: :request do
     end
 
     context "パラメーターが有効な場合" do
+      it "リクエストが成功する事" do
+        post posts_path, params: { post: post_params }
+        expect(response).to have_http_status(302)
+      end
+
       it "データベースへの保存に成功する事" do
         expect{
           post posts_path, params: { post: post_params }
@@ -47,6 +52,11 @@ RSpec.describe "Posts", type: :request do
     end
 
     context "パラメーターが無効な場合" do
+      it "リクエストが成功する事" do
+        post posts_path, params: { post: invalid_post_params }
+        expect(response).to have_http_status(200)  
+      end
+
       it "データベースへの保存に失敗する事" do
         expect{
           post posts_path, params: { post: invalid_post_params }
@@ -61,7 +71,7 @@ RSpec.describe "Posts", type: :request do
   end
 
   describe "GET #show" do
-    it "レスポンスが正しく返ってくる事" do
+    it "リクエストが成功する事" do
       sign_in user
       get post_path(new_post)
       expect(response).to have_http_status(200)
@@ -79,7 +89,7 @@ RSpec.describe "Posts", type: :request do
       get edit_post_path(new_post)
     end
 
-    it "レスポンスが正しく返ってくる事" do
+    it "リクエストが成功する事" do
       expect(response).to have_http_status(200)
     end
 

--- a/spec/system/posts_spec.rb
+++ b/spec/system/posts_spec.rb
@@ -91,6 +91,11 @@ RSpec.describe "Posts", type: :system do
           end
           expect(current_path).to eq root_path
         end
+
+        it "投稿をクリックすると投稿詳細ページに遷移する事" do
+          click_on post.title
+          expect(current_path).to eq post_path(post)
+        end
       end
     end
   end
@@ -173,7 +178,17 @@ RSpec.describe "Posts", type: :system do
         end
       end
     end
+
+    describe "遷移テスト" do
+      it "編集するをクリックすると投稿編集ページに遷移する事" do
+        login(user)
+        visit post_path(post)
+        click_on "編集する"
+        expect(current_path).to eq edit_post_path(post)
+      end
+    end
   end
+
   describe "ユーザー編集ページ" do
     before do
       login(user)

--- a/spec/system/posts_spec.rb
+++ b/spec/system/posts_spec.rb
@@ -100,31 +100,39 @@ RSpec.describe "Posts", type: :system do
       login(user)
       visit new_post_path
     end
-    
-    context "フォーム入力値が正常" do
-      it "新規投稿に成功する事" do
-        fill_in "post_title", with: "test_title"
-        fill_in "post_content", with: "test_content"
-        fill_in "post_extra_fee", with: 1
-        choose "post_change_ちょい変"
-        attach_file "post[image]", "#{Rails.root}/spec/factories/post.test.png"
-        click_on "ドリンクを投稿する"
-        expect(current_path).to eq root_path
-        expect(page).to have_content "新規投稿に成功しました"
+
+    describe "表示テスト" do
+      it "投稿ボタンが「ドリンクを投稿する」という表記になっている事" do
+        expect(page).to have_button "ドリンクを投稿する"
       end
     end
+    
+    describe "遷移テスト" do
+      context "フォーム入力値が正常" do
+        it "新規投稿に成功する事" do
+          fill_in "post_title", with: "test_title"
+          fill_in "post_content", with: "test_content"
+          fill_in "post_extra_fee", with: 1
+          choose "post_change_ちょい変"
+          attach_file "post[image]", "#{Rails.root}/spec/factories/post.test.png"
+          click_on "ドリンクを投稿する"
+          expect(current_path).to eq root_path
+          expect(page).to have_content "新規投稿に成功しました"
+        end
+      end
 
-    context "タイトルが未入力" do
-      it "新規投稿に失敗する事" do
-        fill_in "post_title", with: nil
-        fill_in "post_content", with: "test_content"
-        fill_in "post_extra_fee", with: 1
-        choose "post_change_ちょい変"
-        attach_file "post[image]", "#{Rails.root}/spec/factories/post.test.png"
-        click_on "ドリンクを投稿する"
-        expect(current_path).to eq posts_path
-        expect(page).to have_content "新規投稿に失敗しました"
-        expect(page).to have_content "タイトルを入力してください"
+      context "タイトルが未入力" do
+        it "新規投稿に失敗する事" do
+          fill_in "post_title", with: nil
+          fill_in "post_content", with: "test_content"
+          fill_in "post_extra_fee", with: 1
+          choose "post_change_ちょい変"
+          attach_file "post[image]", "#{Rails.root}/spec/factories/post.test.png"
+          click_on "ドリンクを投稿する"
+          expect(current_path).to eq posts_path
+          expect(page).to have_content "新規投稿に失敗しました"
+          expect(page).to have_content "タイトルを入力してください"
+        end
       end
     end
   end
@@ -163,6 +171,55 @@ RSpec.describe "Posts", type: :system do
             expect(page).to have_selector "img[src$='test.jpg']"  
           end
         end
+      end
+    end
+  end
+  describe "ユーザー編集ページ" do
+    before do
+      login(user)
+      visit edit_post_path(post)
+    end
+    
+    describe "表示テスト" do
+      it "投稿ボタンが「投稿を変更する」という表記になっている事" do
+        expect(page).to have_button "投稿を変更する"
+      end
+    end
+
+    describe "遷移テスト" do
+      let(:another_user_post) { create(:post) }
+
+      context "フォーム入力値が正常" do
+        it "投稿編集に成功する事" do
+          fill_in "post_title", with: "edit_test_title"
+          fill_in "post_content", with: "edit_test_content"
+          fill_in "post_extra_fee", with: 1
+          choose "post_change_ちょい変"
+          attach_file "post[image]", "#{Rails.root}/spec/factories/post.test.png"
+          click_on "投稿を変更する"
+          expect(current_path).to eq post_path(post)
+          expect(page).to have_content "投稿を更新しました"
+        end
+      end
+
+      context "タイトルが未入力" do
+        it "投稿編集に失敗する事" do
+          fill_in "post_title", with: nil
+          fill_in "post_content", with: "edit_test_content"
+          fill_in "post_extra_fee", with: 1
+          choose "post_change_ちょい変"
+          attach_file "post[image]", "#{Rails.root}/spec/factories/post.test.png"
+          click_on "投稿を変更する"
+          expect(current_path).to eq "/posts/#{post.id}"
+          expect(page).to have_content "投稿の編集に失敗しました"
+          expect(page).to have_content "タイトルを入力してください"
+        end
+      end
+
+      it "投稿作成者以外が編集しようとするとトップページに戻される事" do
+        visit edit_post_path(another_user_post)
+        expect(current_path).to eq root_path
+        expect(page).to have_content "他のユーザーの投稿は編集できません"
       end
     end
   end


### PR DESCRIPTION
投稿編集ページの実装

・投稿詳細ページより遷移するよう設定
・パーシャルのフォームをnewアクションとeditアクションで投稿ボタンの表示が変わるよう設定
・投稿したユーザー以外が編集できないよう設定
・RSpec(request,system)スペックテストの追加