### PR TITLE
投稿コメント機能の実装

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,0 +1,27 @@
+class CommentsController < ApplicationController
+  before_action :authenticate_user!
+
+  def create
+    @post = Post.find(params[:post_id])
+    @comment = @post.comments.new(comment_params)
+    if @comment.save
+      redirect_to post_path(@post), notice: "コメントしました"
+    else
+      render post_path(@post)
+      flash.now[:alert] = "コメントに失敗しました"
+    end
+  end
+
+  def destroy
+    @post = Post.find(params[:post_id])
+    @comment = @post.comments.find(params[:id])
+    @comment.destroy
+    redirect_to post_path(@post), notice: "コメントを削除しました"
+  end
+
+  private
+
+  def comment_params
+    params.require(:comment).permit(:comment_content, :user_id, :post_id)
+  end  
+end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -7,8 +7,8 @@ class CommentsController < ApplicationController
     if @comment.save
       redirect_to post_path(@post), notice: "コメントしました"
     else
-      render post_path(@post)
-      flash.now[:alert] = "コメントに失敗しました"
+      redirect_back fallback_location: @comment.post
+      flash[:alert] = "コメントに失敗しました"
     end
   end
 

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -22,6 +22,8 @@ class PostsController < ApplicationController
   end
 
   def show
+    @comments = @post.comments
+    @comment = Comment.new
   end
 
   def edit

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,0 +1,4 @@
+class Comment < ApplicationRecord
+  belongs_to :user
+  belongs_to :post
+end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,4 +1,6 @@
 class Comment < ApplicationRecord
   belongs_to :user
   belongs_to :post
+
+  validates :comment_content, presence: true
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,5 +1,6 @@
 class Post < ApplicationRecord
   belongs_to :user
+  has_many :comments, dependent: :destroy
   
   enum change: { ちょい変: 1, 激変: 2 }
   

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,8 @@
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
-  has_many :posts
+  has_many :posts, dependent: :destroy
+  has_many :comments
   
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable

--- a/app/views/posts/_comment.html.erb
+++ b/app/views/posts/_comment.html.erb
@@ -1,0 +1,38 @@
+<div class="comment-box mt-5">
+  <div class="comment-form-box">
+    <%= form_with(model: [post, comment], local: true) do |f| %>
+      <%= f.hidden_field :user_id, value: current_user.id %>
+      <%= f.hidden_field :post_id %>
+      <div class="form-group">
+        <%= f.text_area :comment_content, class: "form-control", placeholder: "コメントを入力", autofocus: true, rows: 2 %>
+      </div>
+      <div class="d-flex justify-content-center">
+        <%= f.submit "コメントする", class: "btn btn-outline-secondary mt-4 w-25" %>
+      </div>
+    <% end %>
+
+    <div class="mx-auto col-md-10 col-12">
+      <div class="d-flex flex-column">
+        <% post.comments.each do |comment| %>
+          <div class="d-flex mt-4">
+            <div class="me-3">
+              <% if comment.user.image? %>
+                <%= image_tag comment.user.image.url, class: "user-icon", width: '75px' ,height: '75px' %>
+              <% else %>
+                <%= image_tag "default_icon.jpeg", class: "user-icon", width: '75px' ,height: '75px' %>
+              <% end %>
+            </div>
+            <div class="align-self-center fs-5"><%= comment.user.name %></div>
+            <div class="align-self-center ms-auto"><%= comment.created_at.to_s(:datetime_jp) %></div>
+          </div>
+          <div class="p-3 bg-white mt-3"><%= comment.comment_content %></div>
+          <div class ="d-flex justify-content-end">
+            <% if comment.user_id == current_user.id %>
+              <%= link_to "コメント削除", post_comment_path(post, comment), method: :delete, data: { confirm: "本当に削除しますか？" }, class: "text-decoration-none text-black mt-2" %>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -3,7 +3,7 @@
     <div class="row py-5">
       <%= f.label :title ,"タイトルを入力する", class: "col-sm-4 col-12 fw-bold" %>
       <%= f.text_field :title, placeholder: "タイトル", class: "form-control col" %>
-      <p class="error-messages"><%= @post.errors.full_messages_for(:title)[0] %></P>  
+      <p class="error-messages"><%= post.errors.full_messages_for(:title)[0] %></P>  
     </div>
     <div class="row py-5">
       <%= f.label :content ,"投稿内容を入力する", class: "col-sm-4 col-12 fw-bold" %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -43,4 +43,5 @@
       </div>
     </div>
   </div>
+  <%= render partial: "comment", locals: { post: @post, comment: @comment } %>
 </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -8,7 +8,7 @@
         </div>
         <ul class="dropdown-menu" aria-labelledby="dropdownMenu2">
           <li><%= link_to "編集する", edit_post_path(@post.id), class: "dropdown-item", type: "button" %></li>
-          <li><%= link_to "削除する", post_path(@post.id), method: :delete, class: "dropdown-item", type: "button" %></li>
+          <li><%= link_to "削除する", post_path(@post.id), method: :delete, data: { confirm: "本当に削除しますか？" }, class: "dropdown-item", type: "button" %></li>
         </ul>
       </div>
     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,5 +7,7 @@ Rails.application.routes.draw do
   }
 
   resources :users, only: [:show, :edit, :update]
-  resources :posts
+  resources :posts do
+    resources :comments, only: [:create, :destroy]
+  end
 end

--- a/db/migrate/20220507003042_create_comments.rb
+++ b/db/migrate/20220507003042_create_comments.rb
@@ -1,0 +1,11 @@
+class CreateComments < ActiveRecord::Migration[6.1]
+  def change
+    create_table :comments do |t|
+      t.text :comment_content, null: false
+      t.references :user, null: false, foreign_key: true
+      t.references :post, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_29_014654) do
+ActiveRecord::Schema.define(version: 2022_05_07_003042) do
+
+  create_table "comments", charset: "utf8mb4", force: :cascade do |t|
+    t.text "comment_content", null: false
+    t.bigint "user_id", null: false
+    t.bigint "post_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["post_id"], name: "index_comments_on_post_id"
+    t.index ["user_id"], name: "index_comments_on_user_id"
+  end
 
   create_table "posts", charset: "utf8mb4", force: :cascade do |t|
     t.string "title"
@@ -37,4 +47,6 @@ ActiveRecord::Schema.define(version: 2022_04_29_014654) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "comments", "posts"
+  add_foreign_key "comments", "users"
 end

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :comment do
+    comment_content { "テスト投稿" }
+    association :user
+    association :post
+  end
+end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe Comment, type: :model do
+  let(:user) { create(:user) }
+  let(:post) { create(:post, user: user) }
+  let!(:comment) { build(:comment, user: user, post: post) }
+
+  describe "POST /#create" do
+    context "コメントを保存できる場合" do
+      it "リクエストに成功する事" do
+        expect(comment).to be_valid
+      end
+    end
+
+    context "コメントを保存できない場合" do
+      it "コメントが空では投稿できない" do
+        comment.comment_content = nil
+        comment.valid?
+        expect(comment.errors.full_messages).to include "Comment contentを入力してください"
+      end
+
+      it "ユーザーがログインしていなければコメントできない" do
+        comment.user_id = nil
+        comment.valid?
+        expect(comment.errors.full_messages).to include "Userを入力してください"
+      end
+
+      it "投稿したものがなければコメントできない" do
+        comment.post_id = nil
+        comment.valid?
+        expect(comment.errors.full_messages).to include "Postを入力してください"
+      end
+    end
+  end
+end

--- a/spec/requests/comments_spec.rb
+++ b/spec/requests/comments_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe "Comments", type: :request do
+  let(:user) { create(:user) }
+  let(:post) { create(:post, user: user) }
+  let!(:comment) { build(:comment, user: user, post: post) }
+
+  before do
+    sign_in user
+  end
+
+  describe "表示テスト" do
+    it "投稿詳細ページにコメントテーブルの情報が正しく表示されている事" do
+      get post_path(post)
+      expect(response.body).to include comment.comment_content
+    end
+  end
+end

--- a/spec/system/posts_spec.rb
+++ b/spec/system/posts_spec.rb
@@ -143,6 +143,8 @@ RSpec.describe "Posts", type: :system do
   end
 
   describe "投稿詳細ページ" do
+    let!(:comment) { create(:comment, user: user, post: post) }
+
     describe "表示テスト" do
       it "postsテーブルのデータが正しく表示されている事" do
         login(user)
@@ -185,6 +187,32 @@ RSpec.describe "Posts", type: :system do
         visit post_path(post)
         click_on "編集する"
         expect(current_path).to eq edit_post_path(post)
+      end
+
+      it "フォーム入力値が正常な場合コメントに成功する事" do
+        login(user)
+        visit post_path(post)
+        fill_in "comment[comment_content]", with: "Example comment"
+        click_on "コメントする"
+        expect(current_path).to eq post_path(post)
+        expect(page).to have_content "コメントしました"
+      end
+
+      it "コメントが空欄の場合失敗する事" do
+        login(user)
+        visit post_path(post)
+        fill_in "comment[comment_content]", with: nil
+        click_on "コメントする"
+        expect(current_path).to eq post_path(post)
+        expect(page).to have_content "コメントに失敗しました"
+      end
+
+      it "コメント削除をクリックすると削除に成功する事" do
+        login(user)
+        visit post_path(post)
+        click_on "コメント削除"
+        expect(current_path).to eq post_path(post)
+        expect(page).to have_content "コメントを削除しました" 
       end
     end
   end


### PR DESCRIPTION
投稿コメント機能の実装

posrモデルとuserモデルに多対多の関係を持つ中間テーブルとしてcommentモデルを作成しリレーションを設定しました。

・commentテーブルの追加
・投稿詳細ページにてコメント投稿・削除を行えるcreateアクションとdestroyアクションを追加
・コメント機能のRSpec(request,system,model)スペックテストの追加
