### PR TITLE
マイページの機能追加

### DIFF
--- a/app/assets/stylesheets/users/show.scss
+++ b/app/assets/stylesheets/users/show.scss
@@ -1,3 +1,7 @@
 .post-count, .like-count {
   border-top: 1px solid;
 }
+
+.favorites-index {
+  display: none;
+}

--- a/app/assets/stylesheets/users/show.scss
+++ b/app/assets/stylesheets/users/show.scss
@@ -1,7 +1,3 @@
-.post-count, .like-count {
-  border-top: 1px solid;
-}
-
 .favorites-index {
   display: none;
 }

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,6 +3,8 @@ class UsersController < ApplicationController
 
   def show
     @user = User.find(params[:id])
+    @post = @user.posts.all.order("created_at desc")
+    @posts = Post.all
   end
 
   def edit

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -10,6 +10,7 @@ import "channels"
 import "jquery"
 import "bootstrap"
 import "../src/application"
+import "./switch_index"
 
 Rails.start()
 Turbolinks.start()

--- a/app/javascript/packs/switch_index.js
+++ b/app/javascript/packs/switch_index.js
@@ -1,0 +1,10 @@
+$(document).on("turbolinks:load", function(){
+  $(".posts-index-button").click(function(){
+    $(".favorites-index").hide();
+    $(".posts-index").show();
+  });
+  $(".favorites-index-button").click(function(){
+    $(".posts-index").hide();
+    $(".favorites-index").show();
+  });
+});

--- a/app/views/users/_favorites_index.html.erb
+++ b/app/views/users/_favorites_index.html.erb
@@ -1,0 +1,42 @@
+<div class="container-fluid favorites-index">
+  <div class="row">
+    <% posts.each do |posts| %>
+        <div class="col-sm-6 col-12">
+          <% if posts.favorite?(current_user) %>
+            <%= link_to post_path(posts.id), class: "text-decoration-none text-black" do %>
+              <div class="user-liked-container">
+                <%= image_tag posts.image.url, class: "post_image w-100" %>
+                <div class="card-body">
+                  <div class="post-user-detile d-flex mb-2">
+                    <div class="post-show-user-icon me-3">
+                      <% if posts.user.image? %>
+                        <%= image_tag posts.user.image.url, class: "user-icon", width: '40px' ,height: '40px' %>
+                      <% else %>
+                        <%= image_tag "default_icon.jpeg", class: "user-icon", width: '40px' ,height: '40px' %>
+                      <% end %>
+                    </div>
+                    <div class="post-show-user-name align-self-center"><%= posts.user.name %></div>
+                  </div>
+                  <div class="card-title fs-5 no-underline">
+                    <%= posts.title %>
+                  </div>
+                  <div class="card-change mb-2 d-flex">
+                    <% if posts.change == "ちょい変" %>
+                      <div class="badge bg-success me-auto"><%= posts.change %></div>
+                    <% else %>
+                      <div class="badge bg-warning me-auto"><%= posts.change %></div>
+                    <% end %>
+                    <div class="text-secondary me-1"><i class="fa-regular fa-heart"></i><%= posts.favorites.count %></div>
+                    <div class="text-secondary"><i class="fa-regular fa-comment"></i><%= posts.comments.count %></div>
+                  </div>
+                  <div class="card-create d-flex justify-content-end text-secondary">
+                    <%= posts.created_at.to_s(:datetime_jp) %>
+                  </div>
+                </div>
+              </div>
+            <% end %>
+          <% end %>
+        </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/users/_favorites_index.html.erb
+++ b/app/views/users/_favorites_index.html.erb
@@ -1,6 +1,9 @@
 <div class="container-fluid favorites-index">
-  <div class="row">
+  <% if user.favorites.count == 0 %>
+    <div class="text-center">現在いいねをした投稿はありません</div>
+  <% else %>
     <% posts.each do |posts| %>
+      <div class="row">
         <div class="col-sm-6 col-12">
           <% if posts.favorite?(current_user) %>
             <%= link_to post_path(posts.id), class: "text-decoration-none text-black" do %>
@@ -37,6 +40,7 @@
             <% end %>
           <% end %>
         </div>
+      </div>  
     <% end %>
-  </div>
+  <% end %>
 </div>

--- a/app/views/users/_posts_index.html.erb
+++ b/app/views/users/_posts_index.html.erb
@@ -1,40 +1,44 @@
 <div class="container-fluid posts-index">
-  <% post.each do |post| %>
-    <div class="row">
-      <div class="col-sm-6 col-12">
-        <%= link_to post_path(post.id), class: "text-decoration-none text-black" do %>
-          <div class="user-liked-container">
-            <%= image_tag post.image.url, class: "post_image w-100" %>
-            <div class="card-body">
-              <div class="post-user-detile d-flex mb-2">
-                <div class="post-show-user-icon me-3">
-                  <% if post.user.image? %>
-                    <%= image_tag post.user.image.url, class: "user-icon", width: '40px' ,height: '40px' %>
-                  <% else %>
-                    <%= image_tag "default_icon.jpeg", class: "user-icon", width: '40px' ,height: '40px' %>
-                  <% end %>
+  <% if post.count == 0 %>
+    <div class="text-center">現在投稿はありません</div>
+  <% else %>
+    <% post.each do |post| %>
+      <div class="row">
+        <div class="col-sm-6 col-12">
+          <%= link_to post_path(post.id), class: "text-decoration-none text-black" do %>
+            <div class="user-liked-container">
+              <%= image_tag post.image.url, class: "post_image w-100" %>
+              <div class="card-body">
+                <div class="post-user-detile d-flex mb-2">
+                  <div class="post-show-user-icon me-3">
+                    <% if post.user.image? %>
+                      <%= image_tag post.user.image.url, class: "user-icon", width: '40px' ,height: '40px' %>
+                    <% else %>
+                      <%= image_tag "default_icon.jpeg", class: "user-icon", width: '40px' ,height: '40px' %>
+                    <% end %>
+                  </div>
+                  <div class="post-show-user-name align-self-center"><%= post.user.name %></div>
                 </div>
-                <div class="post-show-user-name align-self-center"><%= post.user.name %></div>
-              </div>
-              <div class="card-title fs-5 no-underline">
-                <%= post.title %>
-              </div>
-              <div class="card-change mb-2 d-flex">
-                <% if post.change == "ちょい変" %>
-                  <div class="badge bg-success me-auto"><%= post.change %></div>
-                <% else %>
-                  <div class="badge bg-warning me-auto"><%= post.change %></div>
-                <% end %>
-                <div class="text-secondary me-1"><i class="fa-regular fa-heart"></i><%= post.favorites.count %></div>
-                <div class="text-secondary"><i class="fa-regular fa-comment"></i><%= post.comments.count %></div>
-              </div>
-              <div class="card-create d-flex justify-content-end text-secondary">
-                <%= post.created_at.to_s(:datetime_jp) %>
+                <div class="card-title fs-5 no-underline">
+                  <%= post.title %>
+                </div>
+                <div class="card-change mb-2 d-flex">
+                  <% if post.change == "ちょい変" %>
+                    <div class="badge bg-success me-auto"><%= post.change %></div>
+                  <% else %>
+                    <div class="badge bg-warning me-auto"><%= post.change %></div>
+                  <% end %>
+                  <div class="text-secondary me-1"><i class="fa-regular fa-heart"></i><%= post.favorites.count %></div>
+                  <div class="text-secondary"><i class="fa-regular fa-comment"></i><%= post.comments.count %></div>
+                </div>
+                <div class="card-create d-flex justify-content-end text-secondary">
+                  <%= post.created_at.to_s(:datetime_jp) %>
+                </div>
               </div>
             </div>
-          </div>
-        <% end %>
+          <% end %>
+        </div>
       </div>
-    </div>
+    <% end %>
   <% end %>
 </div>

--- a/app/views/users/_posts_index.html.erb
+++ b/app/views/users/_posts_index.html.erb
@@ -1,0 +1,40 @@
+<div class="container-fluid posts-index">
+  <% post.each do |post| %>
+    <div class="row">
+      <div class="col-sm-6 col-12">
+        <%= link_to post_path(post.id), class: "text-decoration-none text-black" do %>
+          <div class="user-liked-container">
+            <%= image_tag post.image.url, class: "post_image w-100" %>
+            <div class="card-body">
+              <div class="post-user-detile d-flex mb-2">
+                <div class="post-show-user-icon me-3">
+                  <% if post.user.image? %>
+                    <%= image_tag post.user.image.url, class: "user-icon", width: '40px' ,height: '40px' %>
+                  <% else %>
+                    <%= image_tag "default_icon.jpeg", class: "user-icon", width: '40px' ,height: '40px' %>
+                  <% end %>
+                </div>
+                <div class="post-show-user-name align-self-center"><%= post.user.name %></div>
+              </div>
+              <div class="card-title fs-5 no-underline">
+                <%= post.title %>
+              </div>
+              <div class="card-change mb-2 d-flex">
+                <% if post.change == "ちょい変" %>
+                  <div class="badge bg-success me-auto"><%= post.change %></div>
+                <% else %>
+                  <div class="badge bg-warning me-auto"><%= post.change %></div>
+                <% end %>
+                <div class="text-secondary me-1"><i class="fa-regular fa-heart"></i><%= post.favorites.count %></div>
+                <div class="text-secondary"><i class="fa-regular fa-comment"></i><%= post.comments.count %></div>
+              </div>
+              <div class="card-create d-flex justify-content-end text-secondary">
+                <%= post.created_at.to_s(:datetime_jp) %>
+              </div>
+            </div>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -12,8 +12,8 @@
         <div class="user-info mb-5">
           <div class="show-user-name fs-2"><%= @user.name %></div>
           <div class="show-user-email mb-4"><%= @user.email %></div>
-          <div class="post-count mb-2 pt-2">投稿数</div>
-          <div class="like-count mb-2 pt-2">いいね数</div>
+          <div class="posts-count border-top border-secondary mb-2 pt-2">投稿数 <%= @post.count %></div>
+          <div class="favorites-count border-top border-secondary mb-2 pt-2">いいね数 <%= @user.favorites.count %></div>
         </div>
         <%= link_to "編集する", edit_user_path(current_user), class: "btn btn-outline-secondary w-50 mb-3" %>
         <p class="text-center mb-3">
@@ -33,7 +33,7 @@
         </div>
       </div>
       <%= render partial: "posts_index", locals: { post: @post } %>
-      <%= render partial: "favorites_index", locals: { posts: @posts } %>
+      <%= render partial: "favorites_index", locals: { posts: @posts, user: @user } %>
     </div>
   </div>
 </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,7 +1,7 @@
 <div class="user-show-container ms-5 me-5">
   <div class="row py-5 py-md-10">
-    <div class="col-sm-5 col-12">
-      <div class="user-show text-center">
+    <div class="col-md-4 col-12">
+      <div class="user-show text-center mb-4">
         <div class="user-show-icon mb-4">
           <% if current_user.image? %>
             <%= image_tag current_user.image.url, class: "user-icon", width: '200px' ,height: '200px' %>
@@ -23,8 +23,17 @@
         <%= link_to "退会する", registration_path(current_user), data: { confirm: "退会すると全てのデータが削除されます。よろしいですか？" },  method: :delete, class: "btn btn-outline-danger w-50" %>
       </div>
     </div>
-    <div class="col-sm-7 col-12">
-      <!--投稿一覧・いいね一覧を表示予定-->
+    <div class="col-md-8 col-12">
+      <div class="text-center mb-5 mt-3">
+        <div class="btn-group" role="group" aria-label="swich button">
+          <input type="radio" class="btn-check" name="btnradio" id="btnradio1" autocomplete="off" checked>
+          <label class="btn btn-outline-secondary me-3 rounded-end posts-index-button" for="btnradio1">投稿一覧</label>
+          <input type="radio" class="btn-check" name="btnradio" id="btnradio2" autocomplete="off">
+          <label class="btn btn-outline-secondary rounded-start favorites-index-button" for="btnradio2">いいね一覧</label>
+        </div>
+      </div>
+      <%= render partial: "posts_index", locals: { post: @post } %>
+      <%= render partial: "favorites_index", locals: { posts: @posts } %>
     </div>
   </div>
 </div>


### PR DESCRIPTION
マイページに機能の追加

ユーザーマイページにて投稿一覧といいねした投稿の一覧を表示する機能を追加しました。

・コントローラーにpostモデルのすべての情報を取得するインスタンスとユーザーの投稿した投稿を取得するインスタンスをusersコントローラーに追加
・jsにより投稿一覧といいねした投稿の一覧を切り替える機能を追加
・systemスペックテストの追加
